### PR TITLE
Add RunUserQuery endpoint, tests, and example

### DIFF
--- a/examples/RunUserQuery/main.go
+++ b/examples/RunUserQuery/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/hatch-ed-com/ri-sdk-go/pkg/rapididentity"
+)
+
+func main() {
+	baseUrl, err := url.Parse(os.Getenv("RI_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	options := rapididentity.Options{
+		HTTPClient: &http.Client{},
+		BaseUrl:    baseUrl,
+		RapidIdentityUser: &rapididentity.RapidIdentityUser{
+			Username: os.Getenv("RI_USER"),
+			Password: os.Getenv("RI_PWD"),
+		},
+	}
+
+	client, err := rapididentity.New(options)
+	if err != nil {
+		riError, ok := err.(rapididentity.RapidIdentityError)
+		if ok {
+			log.Fatalf("Method: %s, Request URL: %s, Status Code: %d, Message: %s, Reason: %s",
+				riError.Method,
+				riError.ReqUrl,
+				riError.Code,
+				riError.Message,
+				riError.Reason)
+		}
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	input := rapididentity.RunUserQueryInput{
+		SearchType:    "advanced",
+		DelegationIds: []string{"white_pages"},
+		Limit:         10,
+		Query: rapididentity.AuditReportQuery{
+			FieldName:    "givenName",
+			OperatorType: rapididentity.EQUAL,
+			FieldValue:   "a*",
+		},
+	}
+
+	output, err := client.RunUserQuery(input)
+	if err != nil {
+		riError, ok := err.(rapididentity.RapidIdentityError)
+		if ok {
+			log.Fatalf("Method: %s, Request URL: %s, Status Code: %d, Message: %s, Reason: %s",
+				riError.Method,
+				riError.ReqUrl,
+				riError.Code,
+				riError.Message,
+				riError.Reason)
+		}
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", output)
+}

--- a/pkg/rapididentity/RunUserQuery.go
+++ b/pkg/rapididentity/RunUserQuery.go
@@ -1,0 +1,72 @@
+package rapididentity
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"fmt"
+)
+
+// Input for getting users.
+type RunUserQueryInput struct {
+	// The type of search to initiate.
+	// The default is "advanced".
+	SearchType string
+
+	// The maximum amount of users to return.
+	// The default is 1000.
+	Limit int
+
+	// The delegation ids of the delegations that
+	// will be searched.
+	DelegationIds []string
+
+	// The user query to run.
+	Query AuditReportQuery
+}
+
+// Run a user query.
+//
+//meta:operation POST /users
+func (c *Client) RunUserQuery(params RunUserQueryInput) ([]User, error) {
+	var output []User
+	limit := cmp.Or(params.Limit, 1000)
+	searchType := cmp.Or(params.SearchType, "advanced")
+
+	url := fmt.Sprintf("%s/users?search=%s&limit=%d", c.baseEndpoint, searchType, limit)
+	query, err := json.Marshal(params.Query)
+	if err != nil {
+		return nil, err
+	}
+	for _, field := range params.DelegationIds {
+		url = fmt.Sprintf("%s&did=%s", url, field)
+	}
+	requestBody := bytes.NewBuffer(query)
+	req, err := c.GenerateRequest("POST", url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resBody, err := c.ReceiveResponse(res)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(resBody, &output)
+	if err != nil {
+		return nil, RapidIdentityError{
+			Method:  req.Method,
+			ReqUrl:  req.URL,
+			Message: string(resBody),
+			Reason:  err.Error(),
+			Code:    res.StatusCode,
+		}
+	}
+
+	return output, nil
+}

--- a/pkg/rapididentity/RunUserQuery_test.go
+++ b/pkg/rapididentity/RunUserQuery_test.go
@@ -1,0 +1,64 @@
+package rapididentity
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestRunUserQuery(t *testing.T) {
+	t.Parallel()
+	client, mux := setup(t)
+	mux.HandleFunc(baseUrlPath+"/users", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Content-Type", "application/json")
+		testHeader(t, r, "Authorization", "Bearer "+mockServiceIdentity)
+		testQueryParam(t, r, "limit", "1000")
+		testQueryParam(t, r, "search", "advanced")
+		testQueryParam(t, r, "did", "white_pages")
+		var searchPayload AuditReportQuery
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintln(w, err)
+			return
+		}
+		err = json.Unmarshal(reqBody, &searchPayload)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintln(w, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w,
+			`[
+				{
+					"FirstName": "%s"
+				}
+			]`,
+			searchPayload.FieldValue)
+	})
+
+	input := RunUserQueryInput{
+		DelegationIds: []string{"white_pages"},
+		Query: AuditReportQuery{
+			FieldName:    "givenName",
+			OperatorType: EQUAL,
+			FieldValue:   "Jack",
+		},
+	}
+
+	output, err := client.RunUserQuery(input)
+	if err != nil {
+		t.Errorf("got error %s, want none", err)
+	}
+
+	got := output[0].FirstName
+	want := input.Query.FieldValue
+
+	if got != want {
+		t.Errorf("got %s. want %s", got, want)
+	}
+}


### PR DESCRIPTION
Include POST `/users` endpoint to SDK

resolves #11 