### PR TITLE
Cannot search connect action sets in main project

### DIFF
--- a/pkg/rapididentity/SearchConnectActionSets.go
+++ b/pkg/rapididentity/SearchConnectActionSets.go
@@ -159,7 +159,11 @@ func (c *Client) SearchConnectActionSets(ctx context.Context, params SearchConne
 
 	url := fmt.Sprintf("%s/admin/connect/search/actions?searchString=%s&matchAction=%t&matchCase=%t&regex=%t", c.baseEndpoint, params.SearchString, params.MatchAction, params.MatchCase, params.Regex)
 	if params.Project != "" {
-		url = fmt.Sprintf("%s&project=%s", url, params.Project)
+		if params.Project == MainProject {
+			url = fmt.Sprintf("%s&project=", url)
+		} else {
+			url = fmt.Sprintf("%s&project=%s", url, params.Project)
+		}
 	}
 	req, err := c.GenerateRequest(ctx, "GET", url, nil)
 	if err != nil {

--- a/pkg/rapididentity/SearchConnectActionSets.go
+++ b/pkg/rapididentity/SearchConnectActionSets.go
@@ -16,6 +16,8 @@ type SearchConnectActionSetsInput struct {
 
 	// The Connect project to search within.
 	// If empty, all projects will be searched.
+	// For identifying the <Main> project use the
+	// const variable MainProject.
 	Project string `json:"project"`
 
 	// Whether to match action set names.


### PR DESCRIPTION
Fixes issue with not being able to specify the RapidIdentity Connect Main Project.

fixes #20 