### PR TITLE
Add pagination to RunAuditReport method

### DIFF
--- a/examples/RunAuditReport.go/main.go
+++ b/examples/RunAuditReport.go/main.go
@@ -67,6 +67,7 @@ func main() {
 			},
 			OperatorType: rapididentity.AND,
 		},
+		PageSize: 2,
 	}
 
 	ctx := context.Background()

--- a/pkg/rapididentity/RunAuditReport.go
+++ b/pkg/rapididentity/RunAuditReport.go
@@ -27,6 +27,13 @@ type RunAuditReportInput struct {
 	// The query to run
 	// This is a required member
 	Query AuditReportQuery
+
+	// The maximum number of records to return per page
+	PageSize int
+
+	// The token for the next page of results,
+	// retrieved from RunAuditReportOutput.NextPageToken
+	PageToken string
 }
 
 // Audt report query component
@@ -100,6 +107,11 @@ type RunAuditReportOutput struct {
 	// Whether the limit has been reached
 	// for the number of results
 	AdminLimitEnforced bool `json:"adminLimitEnforced"`
+
+	// Token for retrieving the next page of results.
+	// Pass this value as RunAuditReportInput.PageToken in the next call.
+	// Empty when there are no more pages.
+	NextPageToken string `json:"nextPageToken"`
 }
 
 // Result for an audit report query
@@ -199,6 +211,14 @@ type AuditReportExtendedProperties struct {
 //meta:operation POST /reporting/auditQuery
 func (c *Client) RunAuditReport(ctx context.Context, params RunAuditReportInput) (*RunAuditReportOutput, error) {
 	url := fmt.Sprintf("%s/reporting/auditQuery", c.baseEndpoint)
+	sep := "?"
+	if params.PageSize > 0 {
+		url += fmt.Sprintf("%spage_size=%d", sep, params.PageSize)
+		sep = "&"
+	}
+	if params.PageToken != "" {
+		url += fmt.Sprintf("%spage_token=%s", sep, params.PageToken)
+	}
 	query, err := json.Marshal(params.Query)
 	if err != nil {
 		return nil, err

--- a/pkg/rapididentity/RunAuditReport_test.go
+++ b/pkg/rapididentity/RunAuditReport_test.go
@@ -31,7 +31,7 @@ func TestRunAuditReport(t *testing.T) {
 		}
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w,
-			`{ 
+			`{
 				"auditLogRecords": [
 					{
 						"id": "%s"
@@ -82,5 +82,36 @@ func TestRunAuditReport(t *testing.T) {
 
 	if got != want {
 		t.Errorf("got %s. want %s", got, want)
+	}
+}
+
+func TestRunAuditReportPagination(t *testing.T) {
+	t.Parallel()
+	client, mux := setup(t)
+	mux.HandleFunc(baseUrlPath+"/reporting/auditQuery", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testQueryParam(t, r, "page_size", "10")
+		testQueryParam(t, r, "page_token", "abc123")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"auditLogRecords": [], "nextPageToken": "def456"}`)
+	})
+
+	input := RunAuditReportInput{
+		Query:     AuditReportQuery{OperatorType: AND},
+		PageSize:  10,
+		PageToken: "abc123",
+	}
+
+	ctx := context.Background()
+	output, err := client.RunAuditReport(ctx, input)
+	if err != nil {
+		t.Errorf("got error %s, want none", err)
+	}
+
+	got := output.NextPageToken
+	want := "def456"
+
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
 	}
 }


### PR DESCRIPTION
Include `page_size`, `page_token`, and `nextPageToken` in RunAuditReport method to facilitate pagination.

closes #34 