### PR TITLE
Add Run Connect Action Endpoint

### DIFF
--- a/examples/RunConnectAction/main.go
+++ b/examples/RunConnectAction/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/hatch-ed-com/ri-sdk-go/pkg/rapididentity"
+)
+
+func main() {
+	baseUrl, err := url.Parse(os.Getenv("RI_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	options := rapididentity.Options{
+		HTTPClient:      &http.Client{},
+		BaseUrl:         baseUrl,
+		ServiceIdentity: os.Getenv("RI_KEY"),
+	}
+
+	client, err := rapididentity.New(options)
+	if err != nil {
+		riError, ok := err.(rapididentity.RapidIdentityError)
+		if ok {
+			log.Fatalf("Request URL: %s, Status Code: %d, Message: %s", riError.ReqUrl, riError.Code, riError.Message)
+		}
+		log.Fatal(err)
+	}
+
+	input := rapididentity.RunConnectActionInput{
+		Action: rapididentity.ConnectAction{
+			Name: "Test",
+			Args: rapididentity.ArgDefList{
+				{
+					Name:  "id",
+					Value: "1234",
+				},
+				{
+					Name:  "user",
+					Value: "{\"name\":\"John Doe\"}",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	output, err := client.RunConnectAction(ctx, input)
+	if err != nil {
+		riError, ok := err.(rapididentity.RapidIdentityError)
+		if ok {
+			log.Fatalf("Request URL: %s, Status Code: %d, Message: %s", riError.ReqUrl, riError.Code, riError.Message)
+		}
+		log.Fatal(err)
+	}
+
+	fmt.Println(output.Log)
+}

--- a/pkg/rapididentity/Connect.go
+++ b/pkg/rapididentity/Connect.go
@@ -501,6 +501,17 @@ type ConnectAction struct {
 	Args ArgDefList `json:"args" jsonschema:"The input parameters for the action."`
 }
 
+// Input for running a Connect action.
+type RunConnectActionInput struct {
+	Action ConnectAction `json:"action" jsonschema:"The Connect action to run."`
+}
+
+// Output for running a Connect action.
+type RunConnectActionOutput struct {
+	// The HTML log of the action run.
+	Log string `json:"log" jsonschema:"The HTML log of the action run."`
+}
+
 type ConnectActionList []ConnectAction
 
 func (cal ConnectActionList) MarshalJSON() ([]byte, error) {
@@ -848,6 +859,37 @@ func (c *Client) SaveConnectAction(ctx context.Context, params SaveConnectAction
 
 	return &SaveConnectActionOutput{
 		Action: output,
+	}, nil
+}
+
+// Runs a Connect action set and returns the HTML log.
+//
+//meta:operation POST /admin/connect/run
+func (c *Client) RunConnectAction(ctx context.Context, params RunConnectActionInput) (*RunConnectActionOutput, error) {
+	url := fmt.Sprintf("%s/admin/connect/run", c.baseEndpoint)
+	action, err := json.Marshal(params.Action)
+	if err != nil {
+		return nil, err
+	}
+	requestBody := bytes.NewBuffer(action)
+	req, err := c.GenerateRequest(ctx, "POST", url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/html")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resBody, err := c.ReceiveResponse(res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunConnectActionOutput{
+		Log: string(resBody),
 	}, nil
 }
 

--- a/pkg/rapididentity/Connect_test.go
+++ b/pkg/rapididentity/Connect_test.go
@@ -484,6 +484,65 @@ func TestSaveConnectAction(t *testing.T) {
 	}
 }
 
+func TestRunConnectAction(t *testing.T) {
+	t.Parallel()
+	client, mux := setup(t)
+	mux.HandleFunc(baseUrlPath+"/admin/connect/run", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Content-Type", "application/json")
+		testHeader(t, r, "Accept", "text/html")
+		testHeader(t, r, "Authorization", "Bearer "+mockServiceIdentity)
+
+		var action ConnectAction
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintln(w, err)
+			return
+		}
+		err = json.Unmarshal(reqBody, &action)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintln(w, err)
+			return
+		}
+
+		if action.Name != "Test" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, "expected name Test")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "<html><body>Log</body></html>")
+	})
+
+	input := RunConnectActionInput{
+		Action: ConnectAction{
+			Name: "Test",
+			Args: ArgDefList{
+				{
+					Name:  "t",
+					Value: "\" Hello\"",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	output, err := client.RunConnectAction(ctx, input)
+	if err != nil {
+		t.Errorf("got error %s, want none", err)
+	}
+
+	got := output.Log
+	want := "<html><body>Log</body></html>"
+
+	if got != want {
+		t.Errorf("got %s. want %s", got, want)
+	}
+}
+
 func TestDeleteConnectActionById(t *testing.T) {
 	t.Parallel()
 	client, mux := setup(t)


### PR DESCRIPTION
Implement the  POST /admin/connect/run endpoint to execute action sets and retrieve HTML logs.

Changes:

- SDK: Added  RunConnectActionInput  and  RunConnectActionOutput  to Connect.go. Implemented  RunConnectAction with Accept: text/html  header.
- Tests: Added  TestRunConnectAction  to Connect_test.go to verify headers and payloads.
- Example: Created a runnable example

Closes #47