### PR TITLE
Add Password Change endpoint

### DIFF
--- a/examples/SetPassword/main.go
+++ b/examples/SetPassword/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/hatch-ed-com/ri-sdk-go/pkg/rapididentity"
+)
+
+func main() {
+	baseUrl, err := url.Parse(os.Getenv("RI_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	options := rapididentity.Options{
+		HTTPClient: &http.Client{},
+		BaseUrl:    baseUrl,
+		RapidIdentityUser: &rapididentity.RapidIdentityUser{
+			Username: os.Getenv("RI_USER"),
+			Password: os.Getenv("RI_PWD"),
+		},
+	}
+
+	client, err := rapididentity.New(options)
+	if err != nil {
+		riError, ok := err.(rapididentity.RapidIdentityError)
+		if ok {
+			log.Fatalf("Method: %s, Request URL: %s, Status Code: %d, Message: %s, Reason: %s",
+				riError.Method,
+				riError.ReqUrl,
+				riError.Code,
+				riError.Message,
+				riError.Reason)
+		}
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	input := rapididentity.SetPasswordInput{
+		IsSelfService: false,
+		DelegationId:  "c6643ce0-1c9b-4280-8c2c-aa72b5689dce",
+		MustUpdate:    false,
+		Targets:       []string{"996e6333-0731-4d1d-9def-0d0d9afae523"},
+		NewPassword:   "SuperSecret#123",
+	}
+
+	ctx := context.Background()
+	output, err := client.SetPassword(ctx, input)
+	if err != nil {
+		riError, ok := err.(rapididentity.RapidIdentityError)
+		if ok {
+			log.Fatalf("Method: %s, Request URL: %s, Status Code: %d, Message: %s, Reason: %s",
+				riError.Method,
+				riError.ReqUrl,
+				riError.Code,
+				riError.Message,
+				riError.Reason)
+		}
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", output)
+}

--- a/pkg/rapididentity/People.go
+++ b/pkg/rapididentity/People.go
@@ -265,6 +265,40 @@ type RunUserQueryInput struct {
 	Query AuditReportQuery `json:"query" jsonschema:"The user query to run."`
 }
 
+// Input for setting the RapidIdentity Password for the user via delegations.
+type SetPasswordInput struct {
+	// Whether the password change is self-service.
+	IsSelfService bool `json:"isSelfService" jsonschema:"Whether the password change is self-service."`
+	// The delegation ID to use for the password change.
+	DelegationId string `json:"delegationId" jsonschema:"The delegation ID to use for the password change."`
+	// Whether the user must update their password on next login.
+	MustUpdate bool `json:"mustUpdate" jsonschema:"Whether the user must update their password on next login."`
+	// The idautoIDs of the target users.
+	Targets StringList `json:"targets" jsonschema:"The idautoIDs of the target users."`
+	// The new password for the user.
+	NewPassword string `json:"newPassword" jsonschema:"The new password for the user."`
+}
+
+// Result of a password change for a target user.
+type SetPasswordResult struct {
+	// The idautoID of the target user.
+	Target string `json:"target" jsonschema:"The idautoID of the target user."`
+	// Whether the password change was successful.
+	Success bool `json:"success" jsonschema:"Whether the password change was successful."`
+	// The name of the target user.
+	TargetName string `json:"targetName" jsonschema:"The name of the target user."`
+}
+
+// Output of setting the RapidIdentity Password for the user via delegations.
+type SetPasswordOutput []SetPasswordResult
+
+func (spo SetPasswordOutput) MarshalJSON() ([]byte, error) {
+	if spo == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]SetPasswordResult(spo))
+}
+
 // Gets all associated delegations and profiles for the user
 // based on their idautoID. This method will only return
 // delegations and profiles that the invoking session has access.
@@ -348,6 +382,47 @@ func (c *Client) RunUserQuery(ctx context.Context, params RunUserQueryInput) (Us
 		url = fmt.Sprintf("%s&did=%s", url, field)
 	}
 	requestBody := bytes.NewBuffer(query)
+	req, err := c.GenerateRequest(ctx, "POST", url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	resBody, err := c.ReceiveResponse(res)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(resBody, &output)
+	if err != nil {
+		return nil, RapidIdentityError{
+			Method:  req.Method,
+			ReqUrl:  req.URL,
+			Message: string(resBody),
+			Reason:  err.Error(),
+			Code:    res.StatusCode,
+		}
+	}
+
+	return output, nil
+}
+
+// Sets the RapidIdentity Password for the user via delegations.
+//
+//meta:operation POST /profiles/actions/password
+func (c *Client) SetPassword(ctx context.Context, params SetPasswordInput) (SetPasswordOutput, error) {
+	var output SetPasswordOutput
+
+	url := fmt.Sprintf("%s/profiles/actions/password", c.baseEndpoint)
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+	requestBody := bytes.NewBuffer(body)
 	req, err := c.GenerateRequest(ctx, "POST", url, requestBody)
 	if err != nil {
 		return nil, err

--- a/pkg/rapididentity/People_test.go
+++ b/pkg/rapididentity/People_test.go
@@ -145,6 +145,69 @@ func TestRunUserQuery(t *testing.T) {
 	}
 }
 
+func TestSetPassword(t *testing.T) {
+	t.Parallel()
+	client, mux := setup(t)
+	mux.HandleFunc(baseUrlPath+"/profiles/actions/password", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Content-Type", "application/json")
+		testHeader(t, r, "Authorization", "Bearer "+mockServiceIdentity)
+
+		var input SetPasswordInput
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		err = json.Unmarshal(reqBody, &input)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w,
+			`[
+				{
+					"target": "%s",
+					"success": true,
+					"targetName": "Jackson Dart"
+				}
+			]`,
+			input.Targets[0],
+		)
+	})
+
+	input := SetPasswordInput{
+		IsSelfService: false,
+		DelegationId:  "f9710f60-4fe7-405e-91cd-9c9ae88466ab",
+		MustUpdate:    false,
+		Targets:       []string{"019e4ba9-95aa-7a17-b15d-0e1c8ca70467"},
+		NewPassword:   "password123",
+	}
+
+	ctx := context.Background()
+	output, err := client.SetPassword(ctx, input)
+	if err != nil {
+		t.Errorf("got error %s, want none", err)
+	}
+
+	if len(output) != 1 {
+		t.Errorf("got %d results, want 1", len(output))
+	}
+
+	got := output[0].Target
+	want := input.Targets[0]
+
+	if got != want {
+		t.Errorf("got %s. want %s", got, want)
+	}
+
+	if !output[0].Success {
+		t.Errorf("got success false, want true")
+	}
+}
+
 func TestPeople_MarshalJSON_ZeroValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds support for the POST /profiles/actions/password endpoint to enable password changes via delegations.

  Changes:

  - SDK: Added  SetPassword  method and  SetPasswordInput/Output  types to People.go.
  - Testing: Added  TestSetPassword  to People_test.go with mock server validation.
  - Example: Added a new usage example in main.go.

  Closes #46.